### PR TITLE
fix(lint): remove unused imports and add missing dependency

### DIFF
--- a/app/app/protocol-search.tsx
+++ b/app/app/protocol-search.tsx
@@ -123,7 +123,7 @@ export default function ProtocolSearchScreen() {
     } finally {
       setIsSearching(false);
     }
-  }, [searchQuery, params.agency, trpcUtils.search.semantic, trpcUtils.search.searchByAgency, trpcUtils.search.agenciesWithProtocols]);
+  }, [searchQuery, params.agency, params.source, trpcUtils.search.semantic, trpcUtils.search.searchByAgency, trpcUtils.search.agenciesWithProtocols]);
 
   const handleReturnToImageTrend = () => {
     if (params.return_url) {

--- a/components/comparison/ProtocolComparison.tsx
+++ b/components/comparison/ProtocolComparison.tsx
@@ -13,7 +13,6 @@ import {
   TouchableOpacity,
   ScrollView,
   ActivityIndicator,
-  FlatList,
 } from "react-native";
 import { useColors } from "@/hooks/use-colors";
 import { trpc } from "@/lib/trpc";

--- a/components/quick-reference/QuickReferenceCard.tsx
+++ b/components/quick-reference/QuickReferenceCard.tsx
@@ -12,7 +12,7 @@ import {
   TouchableOpacity,
   ScrollView,
 } from "react-native";
-import Animated, { FadeIn, FadeOut, SlideInRight } from "react-native-reanimated";
+import Animated, { FadeIn, SlideInRight } from "react-native-reanimated";
 import { useColors } from "@/hooks/use-colors";
 import { IconSymbol } from "@/components/ui/icon-symbol";
 


### PR DESCRIPTION
## Summary
This PR fixes 3 ESLint warnings in the codebase.

## Changes
1. **protocol-search.tsx**: Added params.source to useCallback dependency array (react-hooks/exhaustive-deps)
2. **ProtocolComparison.tsx**: Removed unused FlatList import
3. **QuickReferenceCard.tsx**: Removed unused FadeOut import

## Testing
- [x] npm run lint passes with 0 warnings
- [x] npm run build passes

## Notes
Part of overnight maintenance work - keeping the codebase clean.