### PR TITLE
fix(e2e): Add E2E mode bypass for faster tests

### DIFF
--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -12,6 +12,7 @@ export {
   injectAuthSession,
   clearAuthSession,
   createMockSession,
+  setE2ETestMode,
   type TestUser,
   type TestSession,
 } from "./auth";

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -81,17 +81,17 @@ export default defineConfig({
     command: "pnpm dev:metro",
     url: "http://localhost:8081",
     reuseExistingServer: true,
-    timeout: 120 * 1000,
+    timeout: 90 * 1000, // 90s startup timeout (reduced from 120s)
     stdout: "pipe",
     stderr: "pipe",
   },
 
-  // Global timeout for each test
-  timeout: 30 * 1000,
+  // Global timeout for each test (increased for visual tests)
+  timeout: process.env.CI ? 45 * 1000 : 30 * 1000,
 
   // Expect timeout
   expect: {
-    timeout: 10 * 1000,
+    timeout: 15 * 1000, // Increased for slow CI environments
     // Visual regression testing configuration
     toHaveScreenshot: {
       // Maximum allowed pixel difference (0.0 - 1.0)


### PR DESCRIPTION
## Summary
This PR fixes E2E test timeout issues in the CI/CD pipeline by adding an E2E mode bypass for authentication loading states.

## Problem
E2E tests were timing out (exceeding 30m limit) due to:
1. Auth loading spinner blocking UI while waiting for Supabase
2. Slow Supabase connection attempts in CI environment
3. Multiple tests waiting 5+ seconds for auth timeout fallback

## Solution
- **Tabs layout**: Added \isE2EMode()\ check to skip loading spinner when in E2E mode
- **useAuth hook**: Added \isE2ETestMode()\ check to skip Supabase calls entirely in E2E
- **Auth timeout**: Reduced from 5s to 3s for faster fallback
- **Auth fixtures**: Now use \ddInitScript\ to inject auth state BEFORE page load
- **Test timeouts**: Increased CI test timeout to 45s, expect timeout to 15s

## How E2E Mode Works
Tests set \e2e-test-mode=true\ in localStorage (via addInitScript before navigation). The app detects this flag and:
1. Skips the auth loading spinner in tabs layout
2. Skips Supabase network calls in useAuth hook
3. Uses injected mock auth data if present

## Testing
- Verified TypeScript compiles without errors
- E2E mode bypasses auth loading as expected

## Related
Fixes the E2E/Visual test timeout issue mentioned in HEARTBEAT.md